### PR TITLE
functions TypeRegistry.shutdownFileSystemWatcherThread and FileSystemWatcher.shutdownAndWait

### DIFF
--- a/springloaded/src/main/java/org/springsource/loaded/TypeRegistry.java
+++ b/springloaded/src/main/java/org/springsource/loaded/TypeRegistry.java
@@ -1538,6 +1538,15 @@ public class TypeRegistry {
 	}
 
 	/**
+	 * Shuts down FileSystemWatcher thread and waits until it is finished.
+	 * @throws InterruptedException 
+	 */
+	public void shutdownFileSystemWatcherThread() throws InterruptedException {
+		if(fsWatcher != null)
+			fsWatcher.shutdownAndWait();
+	}
+
+	/**
 	 * Called for a field operation - trying to determine whether a particular field needs special handling.
 	 *
 	 * @param ids packed representation of the registryId (top 16bits) and typeId (bottom 16bits)

--- a/springloaded/src/main/java/org/springsource/loaded/agent/FileSystemWatcher.java
+++ b/springloaded/src/main/java/org/springsource/loaded/agent/FileSystemWatcher.java
@@ -71,6 +71,17 @@ public class FileSystemWatcher {
 			watchThread.timeToStop();
 		}
 	}
+	
+	/**
+	 * Shutdown the thread and wait until it is finished.
+	 * @throws java.lang.InterruptedException
+	 */
+	public void shutdownAndWait() throws InterruptedException {
+		if (threadRunning) {
+			watchThread.timeToStop();
+			thread.join();
+		}
+	}
 
 	/**
 	 * Add a new file to the list of those being monitored. If the file is something that can be watched, then this method will


### PR DESCRIPTION
## Context

I integrate springloaded and embedded tomcat in [gretty gradle plugin](https://github.com/akhikhl/gretty).
## Problem

When stopping/restarting webapp under embedded tomcat with springloaded agent, tomcat issues warning:

```
The web application [/xyz] appears to have started a thread named [FileSystemWatcher: files=#1 cl=java.net.URLClassLoader@777d673c] 
but has failed to stop it. This is very likely to create a memory leak.
```

The warning is apparently related to the fact that FileSystemWatcher thread is still running, even when related classloader goes out of scope (as by webapp stop/restart),
## Solution

I need the new function `TypeRegistry.shutdownFileSystemWatcherThread` in order to deterministically shut down springloaded threads before webapp is stopped.
