### PR TITLE
Check for null codeSource before attempting to access

### DIFF
--- a/springloaded/src/main/java/org/springsource/loaded/agent/SpringLoadedPreProcessor.java
+++ b/springloaded/src/main/java/org/springsource/loaded/agent/SpringLoadedPreProcessor.java
@@ -525,7 +525,7 @@ public class SpringLoadedPreProcessor implements Constants {
 		} else {
 			try {
 				CodeSource codeSource = protectionDomain.getCodeSource();
-				if (codeSource.getLocation() == null) {
+				if (codeSource == null || codeSource.getLocation() == null) {
 					if (GlobalConfiguration.isRuntimeLogging && log.isLoggable(Level.WARNING)) {
 						log.warning("null codesource for " + slashedClassName);
 					}


### PR DESCRIPTION
In Grails 2.4.3 we have seen some issues where there is a NPE in SpringLoadedPreProcessor.getWatchPathFromProtectionDomain when attempting to access codeSource.getLocation() if codeSource is null.  This seemed to happen inside one of classes that was calling equals on two objects which ended up calling com/sun/proxy/$Proxy56$equals and the protectionDomain looked like it was some default with a null codeSource.  Not sure if this makes sense at all to happen or if something else was going on, but checking for a null codeSource before a null codeSource.getLocation() seems straightforward enough. 