### PR TITLE
Add support for H_NEWINVOKESPECIAL

### DIFF
--- a/springloaded/src/main/java/org/springsource/loaded/support/Java8.java
+++ b/springloaded/src/main/java/org/springsource/loaded/support/Java8.java
@@ -188,6 +188,10 @@ public class Java8 {
 					}
 				}
 				break;
+			case Opcodes.H_NEWINVOKESPECIAL:
+				Class<?> clazz = callerLoader.loadClass(owner.replace("/", "."));
+				implMethod = caller.findConstructor(clazz, implMethodType);
+				break;
 			case Opcodes.H_INVOKEINTERFACE:
 				Handle h = (Handle) bsmArgs[1];
 				String interfaceOwner = h.getOwner();

--- a/springloaded/src/test/java/org/springsource/loaded/test/Java8Tests.java
+++ b/springloaded/src/test/java/org/springsource/loaded/test/Java8Tests.java
@@ -426,6 +426,26 @@ public class Java8Tests extends SpringLoadedTests {
 	}
 
 	@Test
+	public void lambdaWithDoubleDotConstructor() throws Exception {
+		String t = "basic.LambdaO";
+		TypeRegistry typeRegistry = getTypeRegistry(t);
+		byte[] sc = loadBytesForClass(t);
+		ReloadableType rtype = typeRegistry.addType(t, sc);
+
+		Class<?> simpleClass = rtype.getClazz();
+		Result r = runUnguarded(simpleClass, "run");
+
+		r = runUnguarded(simpleClass, "run");
+		assertEquals(3, r.returnValue);
+
+		byte[] renamed = retrieveRename(t, t + "2");
+		rtype.loadNewVersion("002", renamed);
+		r = runUnguarded(simpleClass, "run");
+		assertEquals(4, r.returnValue);
+
+	}
+
+	@Test
 	public void streamWithLambda() throws Exception {
 		String t = "basic.StreamA";
 		TypeRegistry typeRegistry = getTypeRegistry("basic..*");

--- a/testdata-java8/src/main/java/basic/LambdaO.java
+++ b/testdata-java8/src/main/java/basic/LambdaO.java
@@ -1,0 +1,20 @@
+package basic;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class LambdaO {
+
+	public static void main(String[] args) {
+		run();
+	}
+
+	public static int run() {
+		List<Integer> integers = Arrays.asList(1, 2, 3);
+		List<Integer> collected = integers.stream().collect(Collectors.toCollection(ArrayList::new));
+		return collected.size();
+	}
+
+}

--- a/testdata-java8/src/main/java/basic/LambdaO2.java
+++ b/testdata-java8/src/main/java/basic/LambdaO2.java
@@ -1,0 +1,21 @@
+package basic;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class LambdaO2 {
+
+	public static void main(String[] args) {
+		run();
+	}
+
+	public static int run() {
+
+		List<Integer> integers = Arrays.asList(1, 2, 3, 4);
+		List<Integer> collected = integers.stream().collect(Collectors.toCollection(ArrayList::new));
+		return collected.size();
+	}
+
+}


### PR DESCRIPTION
I was noticing that when replacing with code such as
```
Arrays.asList(1, 2, 3).stream()
.collect(Collectors.toCollection(ArrayList::new));
```

the loader throws
```
java.lang.IllegalStateException: nyi 8
```

This is a proposal to fix that and implement the handling of H_NEWINVOKESPECIAL