### PR TITLE
fix ConcurrentModificationException

### DIFF
--- a/springloaded/src/main/java/org/springsource/loaded/TypeRegistry.java
+++ b/springloaded/src/main/java/org/springsource/loaded/TypeRegistry.java
@@ -41,6 +41,7 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.WeakHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -597,9 +598,9 @@ public class TypeRegistry {
 	 * If a type is found to come from a jar, we put the package name in here, which should save us looking for types in
 	 * the same package. This does pre-req that there are no split packages.
 	 */
-	private List<String> packagesFound = Collections.synchronizedList(new ArrayList<String>());
+	private List<String> packagesFound = new CopyOnWriteArrayList<String>();
 
-	private List<String> packagesNotFound = Collections.synchronizedList(new ArrayList<String>());
+	private List<String> packagesNotFound = new CopyOnWriteArrayList<String>();
 
 
 	public static enum CouldBeReloadableDecision {


### PR DESCRIPTION
I think it won't fix the `ConcurrentModificationException` issue by using `Collections.synchronizedList`. I created the following simple test for demonstration. Actually `ConcurrentModificationException` could be thrown even in a single-threaded application when it tries to update the collection during iteration.

```java
package test;

import java.util.ArrayList;
import java.util.Collections;
import java.util.List;
import java.util.Scanner;
import java.util.UUID;

public class TestConcurrentModificationException {
	
	private List<String> testList = Collections.synchronizedList(new ArrayList<String>());
//	private List<String> testList = new CopyOnWriteArrayList<String>();

	public static void main(String[] args) throws IOException {
		new TestConcurrentModificationException().run();
		// Press enter to exit
		System.in.read();
	}
	
	public void run() {
		new Thread(new Runnable() {
			@Override
			public void run() {
				while (true) {
					System.out.println("new iteration");
					for (String str : testList) {
						System.out.println(str);
					}
				}
			}
		}).start();

		new Thread(new Runnable() {
			@Override
			public void run() {
				while(true) {
					testList.add(UUID.randomUUID().toString());
				}
			}
		}).start();
	}
}
```

I propose to use `CopyOnWriteArrayList` to fix the issue based on the [javadoc](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/CopyOnWriteArrayList.html) of the class.

> This array never changes during the lifetime of the iterator, so interference is impossible and the iterator is guaranteed not to throw ConcurrentModificationException.