### PR TITLE
Minor changes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ usage it can't actually handle right now.
 
 Q. With objects changing shape, what happens with respect to reflection?
 A. Reflection results change over time as the objects are reloaded.  For example, modifying a class
-with a new method and calling getDeclaredMethods() after reloading has occurred will mean you see
+with a new method and calling `getDeclaredMethods()` after reloading has occurred will mean you see
 the new method in the results. *But* this does mean if you have existing caches in your system
 that stash reflective information assuming it never changes, those will need to be cleared
 after a reload.
@@ -60,7 +60,7 @@ the invokedynamic instruction and associated new constant pool entries that arri
 
 # Working with the code
 
-	git clone https://github.com/SpringSource/spring-loaded
+	git clone https://github.com/spring-projects/spring-loaded
 
 Once cloned there will be some projects suitable for import into eclipse. The main project and
 some test projects. One of the test projects is an AspectJ project (containing both Java
@@ -76,13 +76,13 @@ To run just the hand crafted ones supply this to the JVM when launching the test
 
     -Dspringloaded.tests.generatedTests=false
 
-NOTE: When running the tests you need to pass -noverify to the JVM also.
+NOTE: When running the tests you need to pass `-noverify` to the JVM also.
 
 Two launch configurations are already included if you are importing these projects into eclipse,
 which run with or without the generated tests.
 
 A gradle build script is included, run './gradlew build' to rebuild the agent - it will be created
-as something like: springloaded/build/libs/springloaded-1.1.5.BUILD-SNAPSHOT.jar
+as something like: `springloaded/build/libs/springloaded-1.1.5.BUILD-SNAPSHOT.jar`
 
 # Can I contribute?
 


### PR DESCRIPTION
- update repo link in `git clone` example
- format method/file names and options in mono-space font