### PR TITLE
refactoring code

### DIFF
--- a/springloaded/src/main/java/org/springsource/loaded/Constants.java
+++ b/springloaded/src/main/java/org/springsource/loaded/Constants.java
@@ -30,6 +30,10 @@ import org.objectweb.asm.Opcodes;
  */
 public interface Constants extends Opcodes {
 
+	public static final int preInvokeSpecial = 0;
+
+	public static final int postInvokeSpecial = 1;
+	
 	public static final Integer DEFAULT_INT = Integer.valueOf(0);
 
 	public static final Byte DEFAULT_BYTE = Byte.valueOf((byte) 0);

--- a/springloaded/src/main/java/org/springsource/loaded/ConstructorCopier.java
+++ b/springloaded/src/main/java/org/springsource/loaded/ConstructorCopier.java
@@ -25,10 +25,6 @@ import org.objectweb.asm.MethodVisitor;
  */
 class ConstructorCopier extends MethodVisitor implements Constants {
 
-	private final static int preInvokeSpecial = 0;
-
-	private final static int postInvokeSpecial = 1;
-
 	// It is important to know when an INVOKESPECIAL is hit, whether it is our actual one that delegates to the super or just
 	// one being invoked due to some early object construction prior to the real INVOKESPECIAL running.  By tracking
 	// how many unitialized objects there are (count the NEWs) and how many INVOKESPECIALs have occurred, it is possible


### PR DESCRIPTION
moved ConstructorCopier constant to Constants interface 
it makes more sence to keep all constants at same place
