### PR TITLE
Don't rewrite non-reloading types.

### DIFF
--- a/springloaded/src/main/java/org/springsource/loaded/MethodInvokerRewriter.java
+++ b/springloaded/src/main/java/org/springsource/loaded/MethodInvokerRewriter.java
@@ -1045,6 +1045,11 @@ public class MethodInvokerRewriter {
 					throw new IllegalStateException("Unable to find classId for " + slashedclassname
 							+ " referenced from invokedynamic in " + this.methodname + "()");
 				}
+				if(typeRegistry.getReloadableType(classId) == null) {
+					// can't rewrite non-reloading type
+					super.visitInvokeDynamicInsn(name, desc, bsm, bsmArgs);
+					return;
+				}
 
 				// Initially only rewriting use of INVOKEDYNAMIC to support Lambda execution
 				// TODO support the more general invokedynamic usage


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-loaded/issues/165

Currently Spring loaded is re-writing methods that attempt reloads on non-reloadable types. This is the root cause of #165

This pull request resolves that and only re-writes if the type is actually reloadable.