### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ allprojects {
     repositories {
         mavenCentral()
 	maven {
-		url "http://maven.springframework.org/milestone"
+		url "https://maven.springframework.org/milestone"
 	}
     }
 }

--- a/gradle/publish-maven.gradle
+++ b/gradle/publish-maven.gradle
@@ -21,12 +21,12 @@ def customizePom(pom, gradleProject) {
 			url = "https://github.com/spring-projects/spring-loaded"
 			organization {
 				name = "Spring IO"
-				url = "http://projects.spring.io/spring-loaded"
+				url = "https://projects.spring.io/spring-loaded"
 			}
 			licenses {
 				license {
 					name "The Apache Software License, Version 2.0"
-					url "http://www.apache.org/licenses/LICENSE-2.0.txt"
+					url "https://www.apache.org/licenses/LICENSE-2.0.txt"
 					distribution "repo"
 				}
 			}

--- a/springloaded/build.gradle
+++ b/springloaded/build.gradle
@@ -13,7 +13,7 @@ task writeNewPom << {
       licenses {
         license {
           name 'The Apache Software License, Version 2.0'
-		  url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+		  url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
           distribution 'repo'
         }
       }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* http://projects.spring.io/spring-loaded (404) migrated to:  
  https://projects.spring.io/spring-loaded ([https](https://projects.spring.io/spring-loaded) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://maven.springframework.org/milestone migrated to:  
  https://maven.springframework.org/milestone ([https](https://maven.springframework.org/milestone) result 302).