### PR TITLE
URL Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ used in Grails 2.
 
 # Installation
 
-1.2.5 has now been released: [springloaded-1.2.5.RELEASE.jar](http://repo.spring.io/release/org/springframework/springloaded/1.2.5.RELEASE/springloaded-1.2.5.RELEASE.jar)
+1.2.5 has now been released: [springloaded-1.2.5.RELEASE.jar](https://repo.spring.io/release/org/springframework/springloaded/1.2.5.RELEASE/springloaded-1.2.5.RELEASE.jar)
 
 1.2.6 snapshots are in this repo area (grab the most recently built .jar):
 <a href="https://repo.spring.io/webapp/#/artifacts/browse/tree/General/libs-snapshot-local/org/springframework/springloaded/1.2.6.BUILD-SNAPSHOT">repo.spring.io</a>
@@ -67,8 +67,8 @@ some test projects. One of the test projects is an AspectJ project (containing b
 and AspectJ code), and one is a Groovy project. To compile these test projects
 in Eclipse you will need the relevant eclipse plugins:
 
-AJDT: update site: `http://download.eclipse.org/tools/ajdt/42/dev/update`
-Groovy-Eclipse: update site: `http://dist.springsource.org/snapshot/GRECLIPSE/e4.2/`
+AJDT: update site: `https://download.eclipse.org/tools/ajdt/42/dev/update`
+Groovy-Eclipse: update site: `https://dist.springsource.org/snapshot/GRECLIPSE/e4.2/`
 
 After importing them you can run the tests.  There are two kinds of tests, hand crafted and
 generated.  Running all the tests including the generated ones can take a while.

--- a/springloaded/src/main/java/org/springsource/loaded/ConstantPoolChecker.java
+++ b/springloaded/src/main/java/org/springsource/loaded/ConstantPoolChecker.java
@@ -24,7 +24,7 @@ import java.util.List;
 
 // TODO does not yet support the new constant pool entry types that come with Java 7
 
-// http://java.sun.com/docs/books/jvms/second_edition/html/ClassFile.doc.html
+// https://java.sun.com/docs/books/jvms/second_edition/html/ClassFile.doc.html
 /**
  * Quickly checks the constant pool for class references, it skips everything else as fast as it can. The class
  * references are then available for checking.

--- a/springloaded/src/main/java/org/springsource/loaded/ConstantPoolChecker2.java
+++ b/springloaded/src/main/java/org/springsource/loaded/ConstantPoolChecker2.java
@@ -26,7 +26,7 @@ import java.util.List;
 
 // TODO try to recall why I created ConstantPoolChecker2, what was up with ConstantPoolChecker?
 
-// http://java.sun.com/docs/books/jvms/second_edition/html/ClassFile.doc.html
+// https://java.sun.com/docs/books/jvms/second_edition/html/ClassFile.doc.html
 /**
  * Enables us to check things quickly in the constant pool. This version accumulates the class references and the method
  * references, for classes that start with 'j' (we want to catch: java/lang). It skips everything it can and the end

--- a/springloaded/src/main/java/org/springsource/loaded/ConstantPoolScanner.java
+++ b/springloaded/src/main/java/org/springsource/loaded/ConstantPoolScanner.java
@@ -28,7 +28,7 @@ import java.util.List;
  * latter look like this 'java/lang/Foo.bar' (the descriptor for the method is not included). Interface methods are
  * skipped.
  *
- * Useful reference: http://java.sun.com/docs/books/jvms/second_edition/html/ClassFile.doc.html
+ * Useful reference: https://java.sun.com/docs/books/jvms/second_edition/html/ClassFile.doc.html
  *
  * @author Andy Clement
  * @since 0.7.3

--- a/springloaded/src/main/java/org/springsource/loaded/Utils.java
+++ b/springloaded/src/main/java/org/springsource/loaded/Utils.java
@@ -1795,7 +1795,7 @@ public class Utils implements Opcodes, Constants {
 			return true;
 		}
 		else {
-			// The 19 conversions, as per section 5.1.2 in: http://java.sun.com/docs/books/jls/third_edition/html/conversions.html
+			// The 19 conversions, as per section 5.1.2 in: https://java.sun.com/docs/books/jls/third_edition/html/conversions.html
 			if (sourceType == byte.class) {
 				if (targetType == short.class || targetType == int.class || targetType == long.class
 						|| targetType == float.class

--- a/springloaded/src/main/java/org/springsource/loaded/ri/ReflectiveInterceptor.java
+++ b/springloaded/src/main/java/org/springsource/loaded/ri/ReflectiveInterceptor.java
@@ -221,7 +221,7 @@ public class ReflectiveInterceptor {
 		// In jdk17u25 there is an extra frame inserted:
 		// "This also fixes a regression introduced in 7u25 in which
 		// getCallerClass(int) is now a Java method that adds an additional frame
-		// that wasn't taken into account." in http://permalink.gmane.org/gmane.comp.java.openjdk.jdk7u.devel/6573
+		// that wasn't taken into account." in https://permalink.gmane.org/gmane.comp.java.openjdk.jdk7u.devel/6573
 		Class<?> caller = sun.reflect.Reflection.getCallerClass(depth);
 		if (caller == ReflectiveInterceptor.class) {
 			// If this is true we have that extra frame on the stack

--- a/testdata/src/main/java/fields/Z.java
+++ b/testdata/src/main/java/fields/Z.java
@@ -13,5 +13,5 @@ public class Z {
 	}
 }
 
-// see http://java.sun.com/docs/books/jvms/second_edition/html/Instructions2.doc5.html.
+// see https://java.sun.com/docs/books/jvms/second_edition/html/Instructions2.doc5.html.
 // TODO [rc1] funky field lookups only necessary for protected fields?


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://permalink.gmane.org/gmane.comp.java.openjdk.jdk7u.devel/6573 (IllegalArgumentException) with 1 occurrences migrated to:  
  https://permalink.gmane.org/gmane.comp.java.openjdk.jdk7u.devel/6573 ([https](https://permalink.gmane.org/gmane.comp.java.openjdk.jdk7u.devel/6573) result IllegalArgumentException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://dist.springsource.org/snapshot/GRECLIPSE/e4.2/ with 1 occurrences migrated to:  
  https://dist.springsource.org/snapshot/GRECLIPSE/e4.2/ ([https](https://dist.springsource.org/snapshot/GRECLIPSE/e4.2/) result 200).
* [ ] http://repo.spring.io/release/org/springframework/springloaded/1.2.5.RELEASE/springloaded-1.2.5.RELEASE.jar with 1 occurrences migrated to:  
  https://repo.spring.io/release/org/springframework/springloaded/1.2.5.RELEASE/springloaded-1.2.5.RELEASE.jar ([https](https://repo.spring.io/release/org/springframework/springloaded/1.2.5.RELEASE/springloaded-1.2.5.RELEASE.jar) result 200).
* [ ] http://download.eclipse.org/tools/ajdt/42/dev/update with 1 occurrences migrated to:  
  https://download.eclipse.org/tools/ajdt/42/dev/update ([https](https://download.eclipse.org/tools/ajdt/42/dev/update) result 301).
* [ ] http://java.sun.com/docs/books/jls/third_edition/html/conversions.html with 1 occurrences migrated to:  
  https://java.sun.com/docs/books/jls/third_edition/html/conversions.html ([https](https://java.sun.com/docs/books/jls/third_edition/html/conversions.html) result 302).
* [ ] http://java.sun.com/docs/books/jvms/second_edition/html/ClassFile.doc.html with 3 occurrences migrated to:  
  https://java.sun.com/docs/books/jvms/second_edition/html/ClassFile.doc.html ([https](https://java.sun.com/docs/books/jvms/second_edition/html/ClassFile.doc.html) result 302).
* [ ] http://java.sun.com/docs/books/jvms/second_edition/html/Instructions2.doc5.html with 1 occurrences migrated to:  
  https://java.sun.com/docs/books/jvms/second_edition/html/Instructions2.doc5.html ([https](https://java.sun.com/docs/books/jvms/second_edition/html/Instructions2.doc5.html) result 302).