### PR TITLE
Patch type registry synchronized and Fix clearing of ReflectionUtils

### DIFF
--- a/springloaded/src/main/java/org/springsource/loaded/ReloadableType.java
+++ b/springloaded/src/main/java/org/springsource/loaded/ReloadableType.java
@@ -450,7 +450,6 @@ public class ReloadableType {
 			} catch(Exception e3) {
 			    //this better not blow up in my face
 			}
-			// ReflectionUtils.clearCache();
 
 			typeRegistry.fireReloadEvent(this, versionsuffix);
 

--- a/springloaded/src/main/java/org/springsource/loaded/ReloadableType.java
+++ b/springloaded/src/main/java/org/springsource/loaded/ReloadableType.java
@@ -441,6 +441,16 @@ public class ReloadableType {
 			tagAsAffectedByReload();
 			tagSupertypesAsAffectedByReload();
 			tagSubtypesAsAffectedByReload();
+			//ReflectionUtils has a cache that needs cleared
+			try {
+				Class<?> reflecutionUtil = Class.forName("org.springframework.util.ReflectionUtils");
+				// java.lang.NoSuchMethodException: org.codehaus.groovy.reflection.ClassInfo$LazyCachedClassRef.clear()
+				Method clearMethod = reflecutionUtil.getMethod("clearCache");//DeclaredMethod("clear");
+				clearMethod.invoke(null);
+			} catch(Exception e3) {
+			    //this better not blow up in my face
+			}
+			// ReflectionUtils.clearCache();
 
 			typeRegistry.fireReloadEvent(this, versionsuffix);
 

--- a/springloaded/src/main/java/org/springsource/loaded/TypeRegistry.java
+++ b/springloaded/src/main/java/org/springsource/loaded/TypeRegistry.java
@@ -1125,10 +1125,13 @@ public class TypeRegistry {
 		if (typeId >= reloadableTypes.length) {
 			resizeReloadableTypeArray(typeId);
 		}
-		reloadableTypes[typeId] = rtype;
-		if ((typeId + 1) > reloadableTypesSize) {
-			reloadableTypesSize = typeId + 1;
+		synchronized(this) {
+			reloadableTypes[typeId] = rtype;
+			if ((typeId + 1) > reloadableTypesSize) {
+				reloadableTypesSize = typeId + 1;
+			}
 		}
+
 		// allocatedIds.put(slashname, rtype);
 		// allocatedButNotYetRegisteredItds.remove(slashname);
 		int cglibIndex = slashname.indexOf("$$EnhancerBy");
@@ -1196,10 +1199,13 @@ public class TypeRegistry {
 		if (typeId >= reloadableTypes.length) {
 			resizeReloadableTypeArray(typeId);
 		}
-		reloadableTypes[typeId] = rtype;
-		if ((typeId + 1) > reloadableTypesSize) {
-			reloadableTypesSize = typeId + 1;
+		synchronized(this) {
+			reloadableTypes[typeId] = rtype;
+			if ((typeId + 1) > reloadableTypesSize) {
+				reloadableTypesSize = typeId + 1;
+			}
 		}
+
 	}
 
 	/**


### PR DESCRIPTION
Fixes concurrency issue where a classload in a concurrent environment with a large number of classes can cause a loss of a TypeRegistry entry. Been running this branch for 3 months on a 380+ Class project with no issues since change.

This also makes spring-loaded work with Java 8 and grails 4.0.x The ReflectionUtils class needed clearing on change to clear cached `Field` references. 