### PR TITLE
fixing springloaded build to work as non java 1.8 minimum for now until asm fixes are done

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@ subprojects {
     apply plugin: 'eclipse'
     apply from: "$rootDir/gradle/publish-maven.gradle"
 	
-    sourceCompatibility = 1.8
-    targetCompatibility = 1.8
+    sourceCompatibility = 1.6
+    targetCompatibility = 1.6
 }
 
 configure(subprojects.findAll { it.name.startsWith('testdata')}) {

--- a/springloaded/build.gradle
+++ b/springloaded/build.gradle
@@ -3,8 +3,8 @@ apply plugin: 'maven'
 group = "org.springframework"
 jar.baseName = 'springloaded'
 
-sourceCompatibility = 1.8
-targetCompatibility = 1.8
+sourceCompatibility = 1.6
+targetCompatibility = 1.6
 
 task writeNewPom {
   doLast {
@@ -47,16 +47,16 @@ dependencies {
 	compile 'org.ow2.asm:asm:5.2'
 	compile 'org.ow2.asm:asm-tree:5.2'
 
-	testCompile 'junit:junit:4.11'
+	testImplementation 'junit:junit:4.11'
 	
-	testCompileOnly files("../testdata-groovy/groovy-all-1.8.6.jar")
-	testCompileOnly project(':testdata')
-	testCompileOnly project(':testdata-aspectj')
-	testCompileOnly project(':testdata-groovy')
-	testCompileOnly project(':testdata-java8')
-	testCompileOnly project(':testdata-plugin')
-	testCompileOnly project(':testdata-subloader')
-	testCompileOnly project(':testdata-superloader')
+	testImplementation files("../testdata-groovy/groovy-all-1.8.6.jar")
+	testImplementation(project(':testdata'))
+	testImplementation(project(':testdata-aspectj')) 
+	testImplementation(project(':testdata-groovy')) 
+	// testImplementation(project(':testdata-java8'))
+	testImplementation(project(':testdata-plugin'))
+	testImplementation(project(':testdata-subloader'))
+	testImplementation(project(':testdata-superloader'))
 }
 
 sourceSets {  


### PR DESCRIPTION
Gradle 6.8.3 has some issues with sourcing the java8 sub project due to it being a newer target compatibility than the library project. Also asm doesn't work as a java 1.8 class and must be targeting java 1.6 for now. Looking into a fix for this but simply bumping ASM version did not suffice.