### PR TITLE
Fixed up SpringPlugin to handle Spring 5 changes

### DIFF
--- a/springloaded/src/main/java/org/springsource/loaded/agent/SpringPlugin.java
+++ b/springloaded/src/main/java/org/springsource/loaded/agent/SpringPlugin.java
@@ -478,6 +478,8 @@ public class SpringPlugin implements LoadtimeInstrumentationPlugin, ReloadEventP
 		clearMapField(mappingRegistryClass, mappingRegistryInstance, "urlLookup");
 		clearMapField(mappingRegistryClass, mappingRegistryInstance, "nameLookup");
 		clearMapField(mappingRegistryClass, mappingRegistryInstance, "corsLookup");
+		//Fixed up SpringPlugin to handle Spring 5 changes
+		clearMapField(mappingRegistryClass, mappingRegistryInstance, "pathLookup");
 		if (debug) {
 			System.out.println("SPRING_PLUGIN: ... cleared out the mapping registry contents");
 		}


### PR DESCRIPTION
When I added javaagent argument to be spring-loaded 1.3 on springboot 2.x, I get the following error -
Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed; nested exception is java.lang.IllegalStateException: Ambiguous handler methods mapped for ,
this code can Fixed up SpringPlugin to handle Spring 5 changes